### PR TITLE
Equivalence between LEM and DNE.

### DIFF
--- a/fe/problems/lem_eq_to_dne.idr
+++ b/fe/problems/lem_eq_to_dne.idr
@@ -1,0 +1,28 @@
+||| Double negation elimination.
+DNE : Type
+DNE = (t : Type) -> Not (Not t) -> t
+
+||| The law of the excluded middle.
+LEM : Type
+LEM = (t : Type) -> Either t (Not t)
+
+||| Proof that double negation elimation implies law of excluded middle.
+total dne_implies_lem : DNE -> LEM
+
+||| Proof that the law of excluded middle implies double negation elimination.
+total lem_implies_dne : LEM -> DNE
+
+-- [SOLUTION]
+
+total not_distributes : {t, t' : Type} -> Not (Either t t') -> (Not t, Not t')
+not_distributes f = (f . Left, f . Right)
+
+total cant_disprove_lem : {t : Type} -> Not (Not (Either t (Not t)))
+cant_disprove_lem {t} = \disproof => let (disproof1, disproof2) = not_distributes disproof in
+                                         disproof2 disproof1
+
+dne_implies_lem x = \t => x (Either t (Not t)) cant_disprove_lem
+
+lem_implies_dne lem = \t => case lem t of
+                                 Left l => \_ => l
+                                 Right r => \x => absurd (x r) -- (x r) has type Void

--- a/fe/problems/triple_negation.idr
+++ b/fe/problems/triple_negation.idr
@@ -1,0 +1,12 @@
+||| Triple negation "elimination".
+TNE : Type
+TNE = (t : Type) -> Not (Not (Not t)) -> Not t
+
+total triple_negation_not_needed : TNE
+
+-- [SOLUTION]
+
+total ev : {t : Type} -> t -> Not (Not t)
+ev x f = f x
+
+triple_negation_not_needed t f x = f (ev x)


### PR DESCRIPTION
It is a classical exercise in logic to show that the law of excluded
middle and double negation are equivalent.
Proving this formally in Idris makes it even more fun.